### PR TITLE
[build]: [Update release workflow to allow non-frozen lockfile instal…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,8 @@ jobs:
           version: 8
           
       - name: Install dependencies
-        run: pnpm install
-        
+        run: pnpm install --no-frozen-lockfile
+          
       - name: Configure Git
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
…lation]

[The release workflow has been updated to modify the dependency installation step. Specifically, the `pnpm install` command now includes the `--no-frozen-lockfile` flag. This change allows for more flexible dependency management during the release process, ensuring that the workflow can handle updates to the lockfile without requiring it to be frozen. This adjustment is expected to improve the robustness and adaptability of the release pipeline.]